### PR TITLE
Improve compression of enhanced

### DIFF
--- a/runcards/runcard.yml
+++ b/runcards/runcard.yml
@@ -2,13 +2,13 @@
 # PDF Set                                         #
 ###################################################
 pdfsetting:
-  pdf: NNPDF40_nnlo_as_0118_1000
+  pdf: 210219-02-rs-nnpdf40-1000
   existing_enhanced: False
 
 ###################################################
 # Size of compressed PDF replicas                 #
 ###################################################
-compressed: 500
+compressed: 100
 
 ###################################################
 # Choice of Minimizer                             #

--- a/src/pycompressor/compressing.py
+++ b/src/pycompressor/compressing.py
@@ -22,7 +22,7 @@ console = Console()
 log = logging.getLogger(__name__)
 
 # Initial scale (in GeV)
-Q0 = 1
+Q0 = 1.65
 # Total number of flavour to 2nf+1=7
 NF = 4
 

--- a/src/pycompressor/compressor.py
+++ b/src/pycompressor/compressor.py
@@ -82,7 +82,7 @@ class Compress:
         erf_res = self.err_func.compute_all_erf(reduc_rep)
         return erf_res
 
-    def final_erfs(self, index):
+    def final_erfs(self, enhanced, index):
         """Compute the final ERF after minimization.
 
         Parameters
@@ -96,7 +96,7 @@ class Compress:
             Dictionary containing the list of estimators and their respective
             values.
         """
-        selected_replicas = self.enhanced[index]
+        selected_replicas = enhanced[index]
         erfs = self.err_func.compute_all_erf(selected_replicas)
         return erfs
 

--- a/src/pycompressor/errfunction.py
+++ b/src/pycompressor/errfunction.py
@@ -276,7 +276,7 @@ class ErfComputation:
         Number of trials
     """
 
-    def __init__(self, prior, est_dic, nreduc, folder, rndgen, trials=1000, norm=True):
+    def __init__(self, prior, est_dic, nreduc, folder, rndgen, trials=10000, norm=True):
         self.prior = prior
         self.est_dic = est_dic
         # Compute estimators for PRIOR replicas

--- a/src/pycompressor/utils.py
+++ b/src/pycompressor/utils.py
@@ -17,6 +17,27 @@ def remap_index(index, shuffled):
     return np.array(new_idx)
 
 
+def map_index(refarr, arr):
+    """Map the the elements in `arr` to the index in which
+    they occur in `refarr`.
+
+    Parameters
+    ----------
+    arr: np.array(int)
+        one dimensional array of integers with size N
+    refarr: np.array(int)
+        one dimentional array of integers with size M
+
+    Returns
+    -------
+    np.array(int)
+        one dimentional array of integers with size N
+    """
+
+    inds = {e:i for i, e in enumerate(refarr)}
+    return np.vectorize(inds.get)(arr)
+
+
 def extract_estvalues(comp_size):
     """Extract the result from the prior for a given
     compressed set (w.r.t the size).

--- a/src/pycompressor/utils.py
+++ b/src/pycompressor/utils.py
@@ -8,13 +8,30 @@ import numpy as np
 log = logging.getLogger(__name__)
 
 
-def remap_index(index, shuffled):
-    new_idx = []
-    for idx in index:
-        # TODO: Implement exception
-        pos = np.where(shuffled == idx)[0][0]
-        new_idx.append(pos)
-    return np.array(new_idx)
+def preprocess_enhanced(enhanced, dec_check=15):
+    """Pre-process the enhanced set by removing duplicates
+    in the PDF grid.
+
+    Parameters
+    ----------
+    enhanced: np.array(float)
+        enhanced PDF grid
+
+    Returns
+    -------
+    tuple(np.array, np.array, np.array)
+        tuple that returns the pre-processed array, the indices
+        that are kept and the number of times each array occured.
+    """
+
+    rounded = np.round(enhanced, dec_check)
+    preprocessed, index, counts = np.unique(
+            rounded,
+            axis=0,
+            return_index=True,
+            return_counts=True
+    )
+    return preprocessed, index, counts
 
 
 def map_index(refarr, arr):
@@ -36,6 +53,39 @@ def map_index(refarr, arr):
 
     inds = {e:i for i, e in enumerate(refarr)}
     return np.vectorize(inds.get)(arr)
+
+
+def restore_permutation(index, shuffle, preprocess):
+    """Undo the maping of indices due to the preprocessing
+    and the shuffling.
+
+    Parameters
+    ----------
+    index: np.array()
+        array containing the final indices
+    shuffle: np.array(float)
+        array containing the permutation
+    preprocess: np.array(float)
+        array containing the indices of the pre-processing
+
+    Returns
+    -------
+    np.array(float)
+        array of index
+    """
+
+    undo_shuffle = shuffle[index]
+    undo_preproc = preprocess[undo_shuffle]
+    return undo_preproc
+
+
+def remap_index(index, shuffled):
+    new_idx = []
+    for idx in index:
+        # TODO: Implement exception
+        pos = np.where(shuffled == idx)[0][0]
+        new_idx.append(pos)
+    return np.array(new_idx)
 
 
 def extract_estvalues(comp_size):


### PR DESCRIPTION
This PR implement the following changes:
- [x] Pre-process the enhanced set by removing duplicates (if there are).  
- [x] Shuffle the resulting pre-processed set prior to compression while keeping track of the indices. Previously, prior and synthetics are just layered on top of each other which presumably increases the likelihood that the minimizer is trapped in some local minima.  